### PR TITLE
Add type packages to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,6 @@
     "@types/gulp-rename": "^2.0.6",
     "@types/gulp-sourcemaps": "^0.0.38",
     "@types/jsonwebtoken": "^9.0.9",
-    "@types/koa": "^2.15.0",
-    "@types/koa-bodyparser": "^4.3.12",
-    "@types/koa-router": "^7.4.8",
-    "@types/koa-static": "^4.0.4",
     "@types/yargs": "^17.0.33",
     "commitizen": "^4.3.1",
     "cz-git": "^1.11.1",
@@ -69,6 +65,10 @@
     "typeorm": "^0.3.21"
   },
   "dependencies": {
+    "@types/koa": "^2.15.0",
+    "@types/koa-bodyparser": "^4.3.12",
+    "@types/koa-router": "^7.4.8",
+    "@types/koa-static": "^4.0.4",
     "jsonwebtoken": "^9.0.2",
     "koa-bodyparser": "^4.4.1",
     "koa-static": "^5.0.0"


### PR DESCRIPTION
Move the type packages from dev dependencies to dependencies so the projects that use the package don't have to install those as their dependencies.