### PR TITLE
Fix transaction middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kool-koala",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kool-koala",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
         "@types/koa": "^2.15.0",
@@ -19,7 +19,8 @@
         "koa-router": "^13.0.1",
         "koa-static": "^5.0.0",
         "reflect-metadata": "^0.2.2",
-        "typeorm": "^0.3.22"
+        "typeorm": "^0.3.22",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "kool-koala": "bin/kool-koala.js"
@@ -55,8 +56,7 @@
         "rimraf": "^6.0.1",
         "semantic-release": "^24.2.3",
         "sqlite3": "^5.1.7",
-        "ts-node": "^10.9.2",
-        "yargs": "^17.7.2"
+        "ts-node": "^10.9.2"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "rimraf": "^6.0.1",
     "semantic-release": "^24.2.3",
     "sqlite3": "^5.1.7",
-    "ts-node": "^10.9.2",
-    "yargs": "^17.7.2"
+    "ts-node": "^10.9.2"
   },
   "config": {
     "commitizen": {
@@ -76,6 +75,7 @@
     "koa-router": "^13.0.1",
     "koa-static": "^5.0.0",
     "reflect-metadata": "^0.2.2",
-    "typeorm": "^0.3.22"
+    "typeorm": "^0.3.22",
+    "yargs": "^17.7.2"
   }
 }

--- a/src/bin/kool-koala.js
+++ b/src/bin/kool-koala.js
@@ -1,2 +1,13 @@
 #!/usr/bin/env node
-require("../index").printKoalaArt();
+const yargs = require('yargs');
+const { hideBin } = require('yargs/helpers');
+const { printKoalaArt } = require('../index');
+
+const argv = yargs(hideBin(process.argv))
+  .scriptName('npx kool-koala')
+  .command('*', 'Default command', (yargs) => {
+    printKoalaArt();
+  })
+  .usage('$0 [args]')
+  .help('h')
+  .alias('h', 'help').argv;

--- a/src/middlewares/transaction-middleware.ts
+++ b/src/middlewares/transaction-middleware.ts
@@ -3,6 +3,10 @@ import { State } from "../types/common/state";
 import { KoalApp } from "../common";
 
 export const transactionMiddleware: Middleware<State> = async (context, next) => {
+  if (!KoalApp.getInstance().getConfiguration().getDatabase()) {
+    await next();
+    return;
+  }
   const queryRunner = KoalApp.getInstance().getDatabaseConnection().createQueryRunner();
   context.state.queryRunner = queryRunner;
   queryRunner.startTransaction();


### PR DESCRIPTION
Make the `transactionMiddleware` doesn't create query runner if database configuration is not provided for the application.