### PR TITLE
fix(static-files): make possible to serve static files from multiple folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+examples-dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "koa": "^2.16.0",
         "koa-bodyparser": "^4.4.1",
         "koa-router": "^13.0.1",
-        "koa-static": "^5.0.0",
         "reflect-metadata": "^0.2.2",
         "typeorm": "^0.3.22",
         "yargs": "^17.7.2"
@@ -8656,42 +8655,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/koa-send": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-5.0.1.tgz",
-      "integrity": "sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "http-errors": "^1.7.3",
-        "resolve-path": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/koa-static": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/koa-static/-/koa-static-5.0.0.tgz",
-      "integrity": "sha512-UqyYyH5YEXaJrf9S8E23GoJFQZXkBVJ9zYYMPGz919MSX1KuvAcycIuS0ci150HCoPf4XQVhQ84Qf8xRPWxFaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.1.0",
-        "koa-send": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 7.6.0"
-      }
-    },
-    "node_modules/koa-static/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
     "node_modules/last-run": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/last-run/-/last-run-2.0.0.tgz",
@@ -13832,6 +13795,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14853,55 +14817,6 @@
       "engines": {
         "node": ">= 10.13.0"
       }
-    },
-    "node_modules/resolve-path": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.4.0.tgz",
-      "integrity": "sha512-i1xevIst/Qa+nA9olDxLWnLk8YZbi8R/7JPbCMcgyWaFR6bKWaexgJgEB5oc2PKMjYdrHynyz0NY+if+H98t1w==",
-      "license": "MIT",
-      "dependencies": {
-        "http-errors": "~1.6.2",
-        "path-is-absolute": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/resolve-path/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/resolve-path/node_modules/http-errors": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-      "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/resolve-path/node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-      "license": "ISC"
-    },
-    "node_modules/resolve-path/node_modules/setprototypeof": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-      "license": "ISC"
     },
     "node_modules/resolve-url": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "koa": "^2.16.0",
     "koa-bodyparser": "^4.4.1",
     "koa-router": "^13.0.1",
-    "koa-static": "^5.0.0",
     "reflect-metadata": "^0.2.2",
     "typeorm": "^0.3.22",
     "yargs": "^17.7.2"

--- a/src/common/koalapp.ts
+++ b/src/common/koalapp.ts
@@ -7,7 +7,6 @@ import { StatusCode } from './status-code';
 import jwt from 'jsonwebtoken';
 import bodyParser from 'koa-bodyparser';
 import { BaseResponse, ErrorBase } from '../types';
-import serve from "koa-static";
 import path from "path";
 import fs from "fs";
 import { AuthorizationService } from '../services';

--- a/src/common/koalapp.ts
+++ b/src/common/koalapp.ts
@@ -109,24 +109,54 @@ export class KoalApp<
   }
 
   registerStaticFileServerMiddleware() {
-    if (!this.configuration.getStaticFilesConfiguration()) {
-      return;
-    }
-    for (const staticFilesConfig of this.configuration.getStaticFilesConfiguration()) {
-      const staticFilesPath = path.isAbsolute(staticFilesConfig.folder) ? staticFilesConfig.folder : path.join(path.dirname(require.main.filename), staticFilesConfig.folder);
-      console.log(`Serving files from: ${staticFilesPath}`);
-      this.koa.use(serve(staticFilesPath));
-      this.koa.use(async (ctx, next) => {
-        const requestPath = ctx.request.path;
+    const configs = this.configuration.getStaticFilesConfiguration();
+    if (!configs) return;
 
-        if (!requestPath.startsWith(this.configuration.getRestPrefix()) && /\.[a-z]+$/.test(requestPath)) {
-          ctx.type = staticFilesConfig.defaultFileMimeType ?? 'html';
-          ctx.body = fs.createReadStream(path.join(staticFilesPath, staticFilesConfig.defaultFile ?? 'index.html'));
-        } else {
-          await next();
+    this.koa.use(async (ctx: Context, next: () => Promise<void>) => {
+      const requestPath = ctx.request.path.replace(/^\//, "");
+      let fileServed = false;
+
+      for (const staticFilesConfig of configs) {
+        const staticFilesPath = path.isAbsolute(staticFilesConfig.folder)
+          ? staticFilesConfig.folder
+          : path.join(path.dirname(require.main.filename), staticFilesConfig.folder);
+        console.log(`Checking static files in: ${staticFilesPath}`);
+
+        const filePath = path.join(staticFilesPath, requestPath);
+
+        if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+          ctx.type = path.extname(filePath).slice(1) || "application/octet-stream";
+          const stat = fs.statSync(filePath);
+          ctx.set("Content-Length", stat.size.toString());
+          ctx.body = fs.createReadStream(filePath);
+          fileServed = true;
+          break;
         }
-      });
-    }
+      }
+
+      if (!fileServed) {
+        for (const staticFilesConfig of configs) {
+          const staticFilesPath = path.isAbsolute(staticFilesConfig.folder)
+            ? staticFilesConfig.folder
+            : path.join(path.dirname(require.main.filename), staticFilesConfig.folder);
+          const defaultFile = staticFilesConfig.defaultFile ?? "index.html";
+          const defaultFilePath = path.join(staticFilesPath, defaultFile);
+
+          if (fs.existsSync(defaultFilePath) && fs.statSync(defaultFilePath).isFile()) {
+            ctx.type = staticFilesConfig.defaultFileMimeType ?? "text/html";
+            const stat = fs.statSync(defaultFilePath);
+            ctx.set("Content-Length", stat.size.toString());
+            ctx.body = fs.createReadStream(defaultFilePath);
+            fileServed = true;
+            break;
+          }
+        }
+      }
+
+      if (!fileServed) {
+        await next();
+      }
+    });
   }
 
   registerMiddlewaresFromConfiguration() {

--- a/tests/common/koalapp.test.ts
+++ b/tests/common/koalapp.test.ts
@@ -17,7 +17,7 @@ class MockController extends ControllerBase {
   registerEndpoints(): void {
     this.router.get('/testingMiddleware', async (context: ParameterizedContext<MockState>, next) => {
       context.body = context.state.middlewareTest;
-      await next();
+      context.status = StatusCode.OK;
     });
   }
 }
@@ -29,7 +29,7 @@ describe('KoalApp', () => {
   describe('Works as expected', () => {
     let koalApp: KoalApp<AuthenticableEntity, {}> | undefined;
     before(() => {
-      //mockConsole();
+      mockConsole();
     })
     describe('Without middlewares', () => {
       before((done) => {
@@ -127,7 +127,7 @@ describe('KoalApp', () => {
     });
 
     after(async () => {
-      //restoreConsole();
+      restoreConsole();
     });
   });
 });

--- a/tsconfig.example.json
+++ b/tsconfig.example.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["examples/**/*", "src/**/*"],
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./examples-dist",
+    "composite": true
+  }
+}


### PR DESCRIPTION
Previously if multiple folders were provided in the configuration for static file serving, only the first one was checked for the static file and it wasn't found, it tried to return the default file from the folder.

The `koa-static` package was removed from the dependencies, since a self written middleware used to handle the static files.